### PR TITLE
build: upgrade parent POM to v66 and modernize dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
@@ -21,22 +22,15 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>49</version>
-        <relativePath/>
+        <version>66</version>
+        <relativePath />
     </parent>
 
     <artifactId>org.apache.sling.installer.factory.subsystems-base</artifactId>
     <version>1.0.0-SNAPSHOT</version>
 
     <name>Apache Sling Subsystems Base Installer</name>
-    <description> 
-        Provides support for subsystems-base files to the Apache Sling OSGi installer
-    </description>
-
-    <properties>
-        <sling.java.version>8</sling.java.version>
-        <bnd.baseline.fail.on.missing>false</bnd.baseline.fail.on.missing>
-    </properties>
+    <description>Provides support for subsystems-base files to the Apache Sling OSGi installer</description>
 
     <scm>
         <connection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-installer-factory-subsystems-base.git</connection>
@@ -44,19 +38,10 @@
         <url>https://github.com/apache/sling-org-apache-sling-installer-factory-subsystems-base.git</url>
     </scm>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.rat</groupId>
-                <artifactId>apache-rat-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>src/test/resources/*-base</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <properties>
+        <sling.java.version>8</sling.java.version>
+        <bnd.baseline.fail.on.missing>false</bnd.baseline.fail.on.missing>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -66,7 +51,12 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
+            <artifactId>org.osgi.framework</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -109,4 +99,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>src/test/resources/*-base</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/org/apache/sling/installer/factories/subsystems/base/impl/Activator.java
+++ b/src/main/java/org/apache/sling/installer/factories/subsystems/base/impl/Activator.java
@@ -23,14 +23,13 @@ import java.util.Hashtable;
 
 import org.apache.sling.installer.api.tasks.ResourceTransformer;
 import org.apache.sling.settings.SlingSettingsService;
+import org.osgi.annotation.bundle.Header;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.util.tracker.ServiceTracker;
-
-import org.osgi.annotation.bundle.Header;
 
 @Header(name = Constants.BUNDLE_ACTIVATOR, value = "${@class}")
 public class Activator implements BundleActivator {
@@ -40,21 +39,23 @@ public class Activator implements BundleActivator {
     private ServiceRegistration<?> serviceReg;
 
     public void start(BundleContext context) throws Exception {
-        slingSettingsTracker = new ServiceTracker<SlingSettingsService, SlingSettingsService>(context,
-            SlingSettingsService.class, null) {
-                @Override
-                public SlingSettingsService addingService(ServiceReference<SlingSettingsService> reference) {
-                    SlingSettingsService slingSettings = super.addingService(reference);
-                    registerInstaller(context, slingSettings);
-                    return slingSettings;
-                }
+        slingSettingsTracker =
+                new ServiceTracker<SlingSettingsService, SlingSettingsService>(
+                        context, SlingSettingsService.class, null) {
+                    @Override
+                    public SlingSettingsService addingService(ServiceReference<SlingSettingsService> reference) {
+                        SlingSettingsService slingSettings = super.addingService(reference);
+                        registerInstaller(context, slingSettings);
+                        return slingSettings;
+                    }
 
-                @Override
-                public void removedService(ServiceReference<SlingSettingsService> reference, SlingSettingsService service) {
-                    unregisterInstaller();
-                    super.removedService(reference, service);
-                }
-        };
+                    @Override
+                    public void removedService(
+                            ServiceReference<SlingSettingsService> reference, SlingSettingsService service) {
+                        unregisterInstaller();
+                        super.removedService(reference, service);
+                    }
+                };
         slingSettingsTracker.open();
     }
 
@@ -67,12 +68,12 @@ public class Activator implements BundleActivator {
         final Dictionary<String, Object> props = new Hashtable<String, Object>();
         props.put(Constants.SERVICE_DESCRIPTION, "Apache Sling Installer Support for subsystem-base files");
         props.put(Constants.SERVICE_VENDOR, "The Apache Software Foundation");
-        this.serviceReg = context.registerService(ResourceTransformer.class,
-                new SubsystemBaseTransformer(slingSettings), props);
+        this.serviceReg =
+                context.registerService(ResourceTransformer.class, new SubsystemBaseTransformer(slingSettings), props);
     }
 
     private void unregisterInstaller() {
-        if ( serviceReg != null ) {
+        if (serviceReg != null) {
             serviceReg.unregister();
             serviceReg = null;
         }

--- a/src/main/java/org/apache/sling/installer/factories/subsystems/base/impl/SubsystemBaseTransformer.java
+++ b/src/main/java/org/apache/sling/installer/factories/subsystems/base/impl/SubsystemBaseTransformer.java
@@ -67,8 +67,8 @@ public class SubsystemBaseTransformer implements ResourceTransformer {
 
     public TransformationResult[] transform(RegisteredResource resource) {
         // TODO start level of the subsystem
-        if ( resource.getType().equals(InstallableResource.TYPE_FILE) ) {
-            if ( resource.getURL().endsWith("." + TYPE_SUBSYSTEM_BASE) ) {
+        if (resource.getType().equals(InstallableResource.TYPE_FILE)) {
+            if (resource.getURL().endsWith("." + TYPE_SUBSYSTEM_BASE)) {
                 logger.info("Found subsystem-base resource {}", resource);
 
                 try {
@@ -82,8 +82,12 @@ public class SubsystemBaseTransformer implements ResourceTransformer {
                     tr.setInputStream(new DeleteOnCloseFileInputStream(ssd.file));
 
                     Map<String, Object> attr = new HashMap<String, Object>();
-                    attr.put(SubsystemConstants.SUBSYSTEM_SYMBOLICNAME, mfAttributes.getValue(SubsystemConstants.SUBSYSTEM_SYMBOLICNAME));
-                    attr.put(SubsystemConstants.SUBSYSTEM_VERSION, mfAttributes.getValue(SubsystemConstants.SUBSYSTEM_VERSION));
+                    attr.put(
+                            SubsystemConstants.SUBSYSTEM_SYMBOLICNAME,
+                            mfAttributes.getValue(SubsystemConstants.SUBSYSTEM_SYMBOLICNAME));
+                    attr.put(
+                            SubsystemConstants.SUBSYSTEM_VERSION,
+                            mfAttributes.getValue(SubsystemConstants.SUBSYSTEM_VERSION));
                     tr.setAttributes(attr);
 
                     return new TransformationResult[] {tr};
@@ -107,7 +111,7 @@ public class SubsystemBaseTransformer implements ResourceTransformer {
             data.file = zf;
             try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zf))) {
                 ZipEntry zie = null;
-                while((zie = jis.getNextEntry()) != null) {
+                while ((zie = jis.getNextEntry()) != null) {
                     String zieName = zie.getName();
                     if ("SUBSYSTEM-MANIFEST-BASE.MF".equals(zieName)) {
                         data.manifest = new Manifest(jis);
@@ -118,7 +122,9 @@ public class SubsystemBaseTransformer implements ResourceTransformer {
                     }
                 }
 
-                data.manifest.getMainAttributes().putValue(SubsystemConstants.SUBSYSTEM_CONTENT, subsystemContent.toString());
+                data.manifest
+                        .getMainAttributes()
+                        .putValue(SubsystemConstants.SUBSYSTEM_CONTENT, subsystemContent.toString());
                 ZipEntry zoe = new ZipEntry("OSGI-INF/SUBSYSTEM.MF");
                 try {
                     zos.putNextEntry(zoe);
@@ -149,18 +155,17 @@ public class SubsystemBaseTransformer implements ResourceTransformer {
         List<String> res = new ArrayList<>();
 
         String val = attrs.getValue(key);
-        if (val == null)
-            return Collections.emptyList();
+        if (val == null) return Collections.emptyList();
 
         for (String r : val.split("[|]")) {
-            if (r.length() > 0)
-                res.add(r);
+            if (r.length() > 0) res.add(r);
         }
         return res;
     }
 
-    private void handleSubsystemArtifact(String artifactName, ZipInputStream zis, ZipOutputStream zos,
-            StringBuilder subsystemContent) throws IOException {
+    private void handleSubsystemArtifact(
+            String artifactName, ZipInputStream zis, ZipOutputStream zos, StringBuilder subsystemContent)
+            throws IOException {
         int idx = artifactName.indexOf('/');
         int idx2 = artifactName.lastIndexOf('/');
         if (idx != idx2 || idx == 0)
@@ -178,13 +183,12 @@ public class SubsystemBaseTransformer implements ResourceTransformer {
                 Attributes ma = jf.getManifest().getMainAttributes();
                 String bsn = ma.getValue(Constants.BUNDLE_SYMBOLICNAME);
                 String version = ma.getValue(Constants.BUNDLE_VERSION);
-                if (version == null)
-                    version = "0";
-                String type = ma.getValue(Constants.FRAGMENT_HOST) != null ?
-                        IdentityNamespace.TYPE_FRAGMENT : IdentityNamespace.TYPE_BUNDLE;
+                if (version == null) version = "0";
+                String type = ma.getValue(Constants.FRAGMENT_HOST) != null
+                        ? IdentityNamespace.TYPE_FRAGMENT
+                        : IdentityNamespace.TYPE_BUNDLE;
                 if (bsn != null) {
-                    if (subsystemContent.length() > 0)
-                        subsystemContent.append(',');
+                    if (subsystemContent.length() > 0) subsystemContent.append(',');
 
                     subsystemContent.append(bsn);
                     subsystemContent.append(';');

--- a/src/test/java/org/apache/sling/installer/factories/subsystems/base/impl/SubsystemBaseTransformerTest.java
+++ b/src/test/java/org/apache/sling/installer/factories/subsystems/base/impl/SubsystemBaseTransformerTest.java
@@ -63,46 +63,51 @@ public class SubsystemBaseTransformerTest {
 
         Set<String> foundBundles = new HashSet<>();
         try (ZipInputStream zis = new ZipInputStream(dcis);
-             JarFile jf = new JarFile(testArchive.getFile())) {
+                JarFile jf = new JarFile(testArchive.getFile())) {
             ZipEntry ze = null;
-            while((ze = zis.getNextEntry()) != null) {
+            while ((ze = zis.getNextEntry()) != null) {
                 foundBundles.add(ze.getName());
-                switch(ze.getName()) {
-                case "OSGI-INF/SUBSYSTEM.MF":
-                    Manifest mf = new Manifest(zis);
-                    Attributes attrs = mf.getMainAttributes();
-                    assertEquals("test1", attrs.getValue("Subsystem-SymbolicName"));
-                    assertEquals("osgi.subsystem.composite", attrs.getValue("Subsystem-Type"));
-                    assertEquals("(c) 2015 yeah!", attrs.getValue("Subsystem-Copyright"));
-                    assertEquals("Extra subsystem headers can go here including very long ones "
-                            + "that would span multiple lines in a manifest", attrs.getValue("Subsystem-Description"));
-                    assertEquals("org.apache.sling.commons.osgi;version=2.3.0;type=osgi.bundle;start-order:=0,"
-                            + "org.apache.sling.commons.json;version=2.0.12;type=osgi.bundle;start-order:=10,"
-                            + "org.apache.sling.commons.mime;version=2.1.8;type=osgi.bundle;start-order:=10",
-                            attrs.getValue("Subsystem-Content"));
-                    break;
-                case "org.apache.sling.commons.osgi-2.3.0.jar":
-                    ZipEntry oze = jf.getEntry("Potential_Bundles/0/org.apache.sling.commons.osgi-2.3.0.jar");
-                    assertArtifactsEqual(oze.getName(), jf.getInputStream(oze), zis);
-                    break;
-                case "org.apache.sling.commons.json-2.0.12.jar":
-                    ZipEntry jze = jf.getEntry("Potential_Bundles/10/org.apache.sling.commons.json-2.0.12.jar");
-                    assertArtifactsEqual(jze.getName(), jf.getInputStream(jze), zis);
-                    break;
-                case "org.apache.sling.commons.mime-2.1.8.jar":
-                    ZipEntry mze = jf.getEntry("Potential_Bundles/10/org.apache.sling.commons.mime-2.1.8.jar");
-                    assertArtifactsEqual(mze.getName(), jf.getInputStream(mze), zis);
-                    break;
+                switch (ze.getName()) {
+                    case "OSGI-INF/SUBSYSTEM.MF":
+                        Manifest mf = new Manifest(zis);
+                        Attributes attrs = mf.getMainAttributes();
+                        assertEquals("test1", attrs.getValue("Subsystem-SymbolicName"));
+                        assertEquals("osgi.subsystem.composite", attrs.getValue("Subsystem-Type"));
+                        assertEquals("(c) 2015 yeah!", attrs.getValue("Subsystem-Copyright"));
+                        assertEquals(
+                                "Extra subsystem headers can go here including very long ones "
+                                        + "that would span multiple lines in a manifest",
+                                attrs.getValue("Subsystem-Description"));
+                        assertEquals(
+                                "org.apache.sling.commons.osgi;version=2.3.0;type=osgi.bundle;start-order:=0,"
+                                        + "org.apache.sling.commons.json;version=2.0.12;type=osgi.bundle;start-order:=10,"
+                                        + "org.apache.sling.commons.mime;version=2.1.8;type=osgi.bundle;start-order:=10",
+                                attrs.getValue("Subsystem-Content"));
+                        break;
+                    case "org.apache.sling.commons.osgi-2.3.0.jar":
+                        ZipEntry oze = jf.getEntry("Potential_Bundles/0/org.apache.sling.commons.osgi-2.3.0.jar");
+                        assertArtifactsEqual(oze.getName(), jf.getInputStream(oze), zis);
+                        break;
+                    case "org.apache.sling.commons.json-2.0.12.jar":
+                        ZipEntry jze = jf.getEntry("Potential_Bundles/10/org.apache.sling.commons.json-2.0.12.jar");
+                        assertArtifactsEqual(jze.getName(), jf.getInputStream(jze), zis);
+                        break;
+                    case "org.apache.sling.commons.mime-2.1.8.jar":
+                        ZipEntry mze = jf.getEntry("Potential_Bundles/10/org.apache.sling.commons.mime-2.1.8.jar");
+                        assertArtifactsEqual(mze.getName(), jf.getInputStream(mze), zis);
+                        break;
                 }
             }
         }
-        assertEquals(new HashSet<>(Arrays.asList("OSGI-INF/SUBSYSTEM.MF",
-                "org.apache.sling.commons.osgi-2.3.0.jar",
-                "org.apache.sling.commons.json-2.0.12.jar",
-                "org.apache.sling.commons.mime-2.1.8.jar")), foundBundles);
+        assertEquals(
+                new HashSet<>(Arrays.asList(
+                        "OSGI-INF/SUBSYSTEM.MF",
+                        "org.apache.sling.commons.osgi-2.3.0.jar",
+                        "org.apache.sling.commons.json-2.0.12.jar",
+                        "org.apache.sling.commons.mime-2.1.8.jar")),
+                foundBundles);
 
-        assertFalse("After closing the stream the temp file should have been deleted.",
-                dcis.file.exists());
+        assertFalse("After closing the stream the temp file should have been deleted.", dcis.file.exists());
     }
 
     @Test
@@ -123,58 +128,64 @@ public class SubsystemBaseTransformerTest {
 
         Set<String> foundBundles = new HashSet<>();
         try (ZipInputStream zis = new ZipInputStream(dcis);
-             JarFile jf = new JarFile(testArchive.getFile())) {
+                JarFile jf = new JarFile(testArchive.getFile())) {
             ZipEntry ze = null;
-            while((ze = zis.getNextEntry()) != null) {
+            while ((ze = zis.getNextEntry()) != null) {
                 foundBundles.add(ze.getName());
-                switch(ze.getName()) {
-                case "OSGI-INF/SUBSYSTEM.MF":
-                    Manifest mf = new Manifest(zis);
-                    Attributes attrs = mf.getMainAttributes();
-                    assertEquals("test1", attrs.getValue("Subsystem-SymbolicName"));
-                    assertEquals("osgi.subsystem.composite", attrs.getValue("Subsystem-Type"));
-                    assertEquals("(c) 2015 yeah!", attrs.getValue("Subsystem-Copyright"));
-                    assertEquals("Extra subsystem headers can go here including very long ones "
-                            + "that would span multiple lines in a manifest", attrs.getValue("Subsystem-Description"));
-                    assertEquals("org.apache.sling.commons.osgi;version=2.3.0;type=osgi.bundle;start-order:=0,"
-                            + "org.apache.sling.commons.json;version=2.0.12;type=osgi.bundle;start-order:=10,"
-                            + "org.apache.sling.commons.mime;version=2.1.8;type=osgi.bundle;start-order:=10,"
-                            + "org.apache.sling.commons.threads;version=3.2.0;type=osgi.bundle;start-order:=20,"
-                            + "org.apache.sling.commons.contentdetection;version=1.0.2;type=osgi.bundle;start-order:=100",
-                            attrs.getValue("Subsystem-Content"));
-                    break;
-                case "org.apache.sling.commons.osgi-2.3.0.jar":
-                    ZipEntry oze = jf.getEntry("Potential_Bundles/0/org.apache.sling.commons.osgi-2.3.0.jar");
-                    assertArtifactsEqual(oze.getName(), jf.getInputStream(oze), zis);
-                    break;
-                case "org.apache.sling.commons.json-2.0.12.jar":
-                    ZipEntry jze = jf.getEntry("Potential_Bundles/10/org.apache.sling.commons.json-2.0.12.jar");
-                    assertArtifactsEqual(jze.getName(), jf.getInputStream(jze), zis);
-                    break;
-                case "org.apache.sling.commons.mime-2.1.8.jar":
-                    ZipEntry mze = jf.getEntry("Potential_Bundles/10/org.apache.sling.commons.mime-2.1.8.jar");
-                    assertArtifactsEqual(mze.getName(), jf.getInputStream(mze), zis);
-                    break;
-                case "org.apache.sling.commons.threads-3.2.0.jar":
-                    ZipEntry tze = jf.getEntry("Potential_Bundles/20/org.apache.sling.commons.threads-3.2.0.jar");
-                    assertArtifactsEqual(tze.getName(), jf.getInputStream(tze), zis);
-                    break;
-                case "org.apache.sling.commons.contentdetection-1.0.2.jar":
-                    ZipEntry cze = jf.getEntry("Potential_Bundles/100/org.apache.sling.commons.contentdetection-1.0.2.jar");
-                    assertArtifactsEqual(cze.getName(), jf.getInputStream(cze), zis);
-                    break;
+                switch (ze.getName()) {
+                    case "OSGI-INF/SUBSYSTEM.MF":
+                        Manifest mf = new Manifest(zis);
+                        Attributes attrs = mf.getMainAttributes();
+                        assertEquals("test1", attrs.getValue("Subsystem-SymbolicName"));
+                        assertEquals("osgi.subsystem.composite", attrs.getValue("Subsystem-Type"));
+                        assertEquals("(c) 2015 yeah!", attrs.getValue("Subsystem-Copyright"));
+                        assertEquals(
+                                "Extra subsystem headers can go here including very long ones "
+                                        + "that would span multiple lines in a manifest",
+                                attrs.getValue("Subsystem-Description"));
+                        assertEquals(
+                                "org.apache.sling.commons.osgi;version=2.3.0;type=osgi.bundle;start-order:=0,"
+                                        + "org.apache.sling.commons.json;version=2.0.12;type=osgi.bundle;start-order:=10,"
+                                        + "org.apache.sling.commons.mime;version=2.1.8;type=osgi.bundle;start-order:=10,"
+                                        + "org.apache.sling.commons.threads;version=3.2.0;type=osgi.bundle;start-order:=20,"
+                                        + "org.apache.sling.commons.contentdetection;version=1.0.2;type=osgi.bundle;start-order:=100",
+                                attrs.getValue("Subsystem-Content"));
+                        break;
+                    case "org.apache.sling.commons.osgi-2.3.0.jar":
+                        ZipEntry oze = jf.getEntry("Potential_Bundles/0/org.apache.sling.commons.osgi-2.3.0.jar");
+                        assertArtifactsEqual(oze.getName(), jf.getInputStream(oze), zis);
+                        break;
+                    case "org.apache.sling.commons.json-2.0.12.jar":
+                        ZipEntry jze = jf.getEntry("Potential_Bundles/10/org.apache.sling.commons.json-2.0.12.jar");
+                        assertArtifactsEqual(jze.getName(), jf.getInputStream(jze), zis);
+                        break;
+                    case "org.apache.sling.commons.mime-2.1.8.jar":
+                        ZipEntry mze = jf.getEntry("Potential_Bundles/10/org.apache.sling.commons.mime-2.1.8.jar");
+                        assertArtifactsEqual(mze.getName(), jf.getInputStream(mze), zis);
+                        break;
+                    case "org.apache.sling.commons.threads-3.2.0.jar":
+                        ZipEntry tze = jf.getEntry("Potential_Bundles/20/org.apache.sling.commons.threads-3.2.0.jar");
+                        assertArtifactsEqual(tze.getName(), jf.getInputStream(tze), zis);
+                        break;
+                    case "org.apache.sling.commons.contentdetection-1.0.2.jar":
+                        ZipEntry cze = jf.getEntry(
+                                "Potential_Bundles/100/org.apache.sling.commons.contentdetection-1.0.2.jar");
+                        assertArtifactsEqual(cze.getName(), jf.getInputStream(cze), zis);
+                        break;
                 }
             }
         }
-        assertEquals(new HashSet<>(Arrays.asList("OSGI-INF/SUBSYSTEM.MF",
-                "org.apache.sling.commons.osgi-2.3.0.jar",
-                "org.apache.sling.commons.json-2.0.12.jar",
-                "org.apache.sling.commons.mime-2.1.8.jar",
-                "org.apache.sling.commons.threads-3.2.0.jar",
-                "org.apache.sling.commons.contentdetection-1.0.2.jar")), foundBundles);
+        assertEquals(
+                new HashSet<>(Arrays.asList(
+                        "OSGI-INF/SUBSYSTEM.MF",
+                        "org.apache.sling.commons.osgi-2.3.0.jar",
+                        "org.apache.sling.commons.json-2.0.12.jar",
+                        "org.apache.sling.commons.mime-2.1.8.jar",
+                        "org.apache.sling.commons.threads-3.2.0.jar",
+                        "org.apache.sling.commons.contentdetection-1.0.2.jar")),
+                foundBundles);
 
-        assertFalse("After closing the stream the temp file should have been deleted.",
-                dcis.file.exists());
+        assertFalse("After closing the stream the temp file should have been deleted.", dcis.file.exists());
     }
 
     private void assertArtifactsEqual(String name, InputStream is1, InputStream is2) throws IOException {
@@ -202,7 +213,7 @@ public class SubsystemBaseTransformerTest {
         }
     }
 
-    public static byte [] suckStreams(InputStream is) throws IOException {
+    public static byte[] suckStreams(InputStream is) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         pumpStreams(is, baos);
         return baos.toByteArray();


### PR DESCRIPTION
Upgrades the Maven parent POM and cleans up project configuration and code style.

**Changes:**
- Bump `sling-bundle-parent` from version 49 to 66
- Replace `osgi.core` dependency with `org.osgi.framework` and `org.osgi.util.tracker`
- Add XML declaration to `pom.xml`
- Reorder `<properties>` and `<build>` sections to follow standard POM element order
- Trim whitespace from `<description>` element
- Reformat `Activator.java` and `SubsystemBaseTransformer.java` for consistent code style (brace placement, line wrapping)
- Move `@Header` import to be grouped with other OSGi imports

Note: The diff was truncated; additional minor formatting changes may be present in `SubsystemBaseTransformer.java`.

Co-authored-by: Maia <maia@noreply>